### PR TITLE
Add basic PHPUnit setup and router test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,15 @@
     "description": "Imagilab E-commerce",
     "autoload": {
         "psr-4": {
-
             "Leandroconrado\\Imagilab\\": "src/",
             "App\\": "app/",
             "Core\\": "core/",
             "App\\Helpers\\": "app/Helpers/"
-            
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
         }
     },
     "authors": [
@@ -23,5 +26,8 @@
         "twig/twig": "^3.21",
         "filp/whoops": "^2.18",
         "phpmailer/phpmailer": "^6.10"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="imagilab Test Suite">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Core\Router;
+
+class DummyController
+{
+    public static bool $called = false;
+
+    public function hello(): void
+    {
+        self::$called = true;
+    }
+}
+
+class RouterTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        DummyController::$called = false;
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/hello';
+    }
+
+    public function testDispatchRoutesToController(): void
+    {
+        $router = new Router();
+        $router->add('GET', '/hello', [DummyController::class, 'hello']);
+        $router->dispatch();
+        $this->assertTrue(DummyController::$called);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,17 @@
+<?php
+spl_autoload_register(function ($class) {
+    $prefixes = [
+        'Core\\' => __DIR__ . '/../core/',
+        'App\\' => __DIR__ . '/../app/',
+    ];
+    foreach ($prefixes as $prefix => $baseDir) {
+        $len = strlen($prefix);
+        if (strncmp($prefix, $class, $len) === 0) {
+            $relativeClass = substr($class, $len);
+            $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
+            if (file_exists($file)) {
+                require $file;
+            }
+        }
+    }
+});


### PR DESCRIPTION
## Summary
- add PHPUnit test bootstrap and config
- test Router dispatch routing
- autoload `Tests\` namespace and add PHPUnit dev dependency

## Testing
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685802a1060483289e97568b5fcd8a21